### PR TITLE
add questions group order and sort base on it

### DIFF
--- a/v2/client/src/components/pages/UserResults/index.js
+++ b/v2/client/src/components/pages/UserResults/index.js
@@ -50,7 +50,6 @@ const panels = {
 class UserResults extends Component {
   state = {
     selectedUserId: null,
-    selectedUserRole: null,
     toggle: 'left',
   };
 
@@ -70,14 +69,12 @@ class UserResults extends Component {
       await this.fetchSessionsData('trainer', state.trainer._id);
       this.setState({
         selectedUserId: state.trainer._id,
-        selectedUserRole: state.trainer.role,
       });
     } else if (state && state.trainer) {
       await fetchUserResults(state.trainer._id, state.trainer.role);
       await this.fetchSessionsData(state.trainer.role, state.trainer._id);
       this.setState({
         selectedUserId: state.trainer._id,
-        selectedUserRole: state.trainer.role,
       });
     } else {
       await fetchUserResults(userId, viewLevel);

--- a/v2/client/src/components/pages/survey/SurveyQs.js
+++ b/v2/client/src/components/pages/survey/SurveyQs.js
@@ -269,19 +269,19 @@ const questionsRender = (
   postcodeValid
 ) => {
   const demographicQs = arrayOfQuestions.filter(
-    question => question.group === 'demographic'
+    question => question.group.text === 'demographic'
   );
 
   const behaviourQs = arrayOfQuestions.filter(
-    question => question.group === 'Behavioural Insights'
+    question => question.group.text === 'Behavioural Insights'
   );
 
   const trainerQs = arrayOfQuestions.filter(
-    question => question.group === 'about your trainer'
+    question => question.group.text === 'about your trainer'
   );
 
   const teachingQs = arrayOfQuestions.filter(
-    question => question.group === 'about your usual way of teaching'
+    question => question.group.text === 'about your usual way of teaching'
   );
 
   return [demographicQs, behaviourQs, trainerQs, teachingQs]
@@ -289,7 +289,7 @@ const questionsRender = (
     .map((section, index) => (
       // map through each section
       <QuestionWrapper key={section[0].group}>
-        <SectionCategory>{section[0] && section[0].group}</SectionCategory>
+        <SectionCategory>{section[0] && section[0].group.text}</SectionCategory>
         {section &&
           section.map(el => {
             // map through all the questions

--- a/v2/client/src/components/pages/survey/index.js
+++ b/v2/client/src/components/pages/survey/index.js
@@ -66,7 +66,6 @@ class Survey extends Component {
   sectionChange = (direction, uniqueGroups) => {
     let newSection;
     const { section } = this.state;
-
     if (direction === 'forward') {
       switch (section) {
         // first section
@@ -306,7 +305,7 @@ class Survey extends Component {
 
     if (formState && surveyDetails) {
       const questions = surveyDetails.questionsForSurvey.filter(question => {
-        return uniqueGroups.includes(question.group);
+        return uniqueGroups.includes(question.group.text);
       });
       const numberOfQs = questions.length;
       const numberOfAs = Object.values(formState).length;
@@ -391,7 +390,7 @@ class Survey extends Component {
     const { surveyType, sessionId, questionsForSurvey } = surveyData.surveyData;
     // these are the base of validation in the backend (checked against formstate to see if everything was getting answered correctly)
     const questionsForParticipant = questionsForSurvey.filter(question => {
-      return uniqueGroups.includes(question.group);
+      return uniqueGroups.includes(question.group.text);
     });
 
     const { formState, PIN, disagreedToResearch, completionRate } = this.state;
@@ -487,7 +486,7 @@ class Survey extends Component {
                       const questions =
                         surveyDetails &&
                         surveyDetails.questionsForSurvey.filter(
-                          question => question.group === group
+                          question => question.group.text === group
                         );
                       if (section === group) {
                         const unanswered = questions

--- a/v2/client/src/reducers/surveyReducer.js
+++ b/v2/client/src/reducers/surveyReducer.js
@@ -19,7 +19,7 @@ const initialState = {
   preSurveyResponses: null,
 };
 
-const createGroupsArray = obj => [...new Set(obj.map(e => e.group))];
+const createGroupsArray = obj => [...new Set(obj.map(e => e.group.text))];
 
 const fetchedSurveyData = (state = initialState, action) => {
   const { type, payload } = action;

--- a/v2/server/controllers/feedback/exportCSVData.js
+++ b/v2/server/controllers/feedback/exportCSVData.js
@@ -30,7 +30,7 @@ module.exports = async (req, res, next) => {
             }
 
             newResponseObj[
-              `${question.group}: ${subGroupText} ${question.text}`
+              `${question.group.text}: ${subGroupText} ${question.text}`
             ] = answer.answer;
             return newResponseObj;
           });

--- a/v2/server/database/DBConstants.js
+++ b/v2/server/database/DBConstants.js
@@ -37,10 +37,13 @@ module.exports.surveyTypes = [
 const questionConstants = {};
 
 questionConstants.groups = {
-  DEMOGRAPHIC: 'demographic',
-  BEHAVIOURAL: 'Behavioural Insights',
-  ABOUT_YOUR_TRAINER: 'about your trainer',
-  ABOUT_YOUR_USUAL_WAY_OF_TEACHING: 'about your usual way of teaching',
+  DEMOGRAPHIC: { text: 'demographic', order: 1 },
+  BEHAVIOURAL: { text: 'Behavioural Insights', order: 2 },
+  ABOUT_YOUR_TRAINER: { text: 'about your trainer', order: 3 },
+  ABOUT_YOUR_USUAL_WAY_OF_TEACHING: {
+    text: 'about your usual way of teaching',
+    order: 4,
+  },
 };
 
 questionConstants.subGroupText = {

--- a/v2/server/database/models/Question.js
+++ b/v2/server/database/models/Question.js
@@ -11,8 +11,11 @@ const questionSchema = new Schema({
   },
   code: String,
   // the general group
-  // [ "ABOUT YOU", "ABOUT YOUR TRAINER", "ABOUT YOUR USUAL WAY OF TEACHING"]
-  group: String,
+  // [ { text: "ABOUT YOU", order: 1 }, { text: "ABOUT YOUR TRAINER", order: 2 }]
+  group: {
+    text: String,
+    order: Number,
+  },
 
   // sub groups
   // ["Did your trainer ask questions...", "Did your trainer...", ...]

--- a/v2/server/database/queries/feedback/exportData.js
+++ b/v2/server/database/queries/feedback/exportData.js
@@ -19,7 +19,7 @@ module.exports.exportData = () =>
     },
     {
       $sort: {
-        'question.group': 1,
+        'question.group.order': 1,
         'question.subGroup.name': 1,
         'question.subGroup.order': -1,
       },
@@ -98,7 +98,7 @@ module.exports.exportData = () =>
         'answers._id': 1,
         'answers.answer': 1,
         'answers.question.text': 1,
-        'answers.question.group': 1,
+        'answers.question.group.text': 1,
         'answers.question.subGroup': 1,
       },
     },

--- a/v2/server/database/queries/feedback/feedback.js
+++ b/v2/server/database/queries/feedback/feedback.js
@@ -64,8 +64,8 @@ module.exports.feedback = async (trainerId, sessionId, surveyType) => {
         $and: [
           {
             $or: [
-              { 'questions.group': 'about your trainer' },
-              { 'questions.group': 'about your usual way of teaching' },
+              { 'questions.group.text': 'about your trainer' },
+              { 'questions.group.text': 'about your usual way of teaching' },
             ],
           },
         ],
@@ -118,9 +118,9 @@ module.exports.feedback = async (trainerId, sessionId, surveyType) => {
 
     const counter = answersArr.map(answer => {
       const surveyAnswerCounter = answer[1].reduce((acc, cur) => {
-        const surveyType = cur.split('/')[0];
+        const surveyTypeArray = cur.split('/')[0];
 
-        acc[surveyType] = (acc[surveyType] || 0) + 1;
+        acc[surveyTypeArray] = (acc[surveyTypeArray] || 0) + 1;
 
         return acc;
       }, {});

--- a/v2/server/database/queries/surveys/surveyQuestions.js
+++ b/v2/server/database/queries/surveys/surveyQuestions.js
@@ -15,7 +15,7 @@ const surveyQs = async (surveyType, shortId) => {
       $match: { surveyType },
     },
     {
-      $sort: { 'subGroup.name': 1, 'subGroup.order': -1 },
+      $sort: { 'group.order': 1, 'subGroup.name': 1, 'subGroup.order': -1 },
     },
   ]);
 


### PR DESCRIPTION
for some reasons the production DB not retrieving the data in the same order with the dev DB, so the solution to get the same order of questions to change the question schema, change the `group` to be an object instead of the string
```js
group: {
  text: String,
  order: Number,
}
```