### PR TITLE
Fix number comparison

### DIFF
--- a/v2/client/src/components/pages/survey/index.js
+++ b/v2/client/src/components/pages/survey/index.js
@@ -348,7 +348,10 @@ class Survey extends Component {
   testNumber = (code, number) => {
     const { maxNum } = this.state;
     if (['B1', 'B2', 'B3'].includes(code)) {
-      if (maxNum < number) {
+      // turn number and maxnumber into numbers for comparison
+      const numInt = Number(number);
+      const maxInt = Number(maxNum);
+      if (maxInt < numInt) {
         message.error(
           'Number cannot be greater than the total number of people you have seen in the last week'
         );

--- a/v2/server/database/data/production/questions.js
+++ b/v2/server/database/data/production/questions.js
@@ -42,13 +42,13 @@ const demographics = surveyType => [
     surveyType,
     participantField: 'region',
   },
-  {
-    text: 'Please enter the first date of your Connect 5 training session 1',
-    questionType: questionConstants.questionTypes.date,
-    group: questionConstants.groups.DEMOGRAPHIC,
-    surveyType,
-    participantField: 'Session1Date',
-  },
+  // {
+  //   text: 'Please enter the first date of your Connect 5 training session 1',
+  //   questionType: questionConstants.questionTypes.date,
+  //   group: questionConstants.groups.DEMOGRAPHIC,
+  //   surveyType,
+  //   participantField: 'Session1Date',
+  // },
   {
     text: 'Please enter your job title',
     questionType: questionConstants.questionTypes.text,


### PR DESCRIPTION
Noticed that a new bug has emerged where it was correctly comparing the maximum number when setting the number of people. Have fixed this now

Also update the questions in production data as we didn't need the session date in there