### PR TITLE
fix clean filters when change page

### DIFF
--- a/client/src/components/common/EditEmail/index.js
+++ b/client/src/components/common/EditEmail/index.js
@@ -365,9 +365,14 @@ class EditEmail extends Component {
       checkedList,
     } = this.state;
     const { scheduleNewEmail, sessionId, surveyType } = this.props;
+
+    if (checkedList.length < 1) {
+      return message.error('You should add recipients emails');
+    }
+
     if (scheduledDate && selectedTime) {
       const date = moment(`${scheduledDate} ${selectedTime}`);
-      scheduleNewEmail(
+      return scheduleNewEmail(
         {
           date,
           sessionId,
@@ -377,10 +382,9 @@ class EditEmail extends Component {
         },
         this.done
       );
-    } else {
-      this.setState({ error: 'Select schedule date and time' });
-      message.error('Select schedule date and time');
     }
+    this.setState({ error: 'Select schedule date and time' });
+    return message.error('Select schedule date and time');
   };
 
   handleAddEmailsClick = () => {

--- a/client/src/components/common/FilterResults/index.js
+++ b/client/src/components/common/FilterResults/index.js
@@ -48,11 +48,23 @@ class FilterResults extends Component {
   };
 
   componentDidMount() {
+    this.updateFilters();
+  }
+
+  componentDidUpdate(prevProps) {
+    const { id, role } = this.props;
+    if (role !== prevProps.role || id !== prevProps.id) {
+      this.updateFilters();
+    }
+  }
+
+  updateFilters = () => {
     const {
       fetchLocalLeads,
       fetchAllTrainers,
       fetchLocalLeadTrainersGroup: fetchLocalLeadTrainersGroupAction,
       setFilters,
+      resetFilters,
     } = this.props;
     const { id, role, defaultFilters } = this.props;
 
@@ -62,13 +74,13 @@ class FilterResults extends Component {
       fetchAllTrainers();
       fetchLocalLeads();
     }
-
+    resetFilters();
     if (defaultFilters) {
       Object.entries(defaultFilters).forEach(([key, value]) => {
         setFilters(value, key);
       });
     }
-  }
+  };
 
   clearAllFilter = () => {
     const {

--- a/client/src/components/common/Reach/index.js
+++ b/client/src/components/common/Reach/index.js
@@ -87,6 +87,7 @@ const Reach = ({
   return (
     <div>
       <Head>Sessions</Head>
+
       <FilterResults
         role={role}
         handleFilteredData={handleFilteredData}

--- a/client/src/components/pages/SessionDetails/ManageAttendees/EmailTemplate.js
+++ b/client/src/components/pages/SessionDetails/ManageAttendees/EmailTemplate.js
@@ -11,7 +11,6 @@ import {
 } from '../SessionDetails.Style';
 
 const EmailTemplate = ({ activeEmailTemplate }) => {
-  console.log('activeEmailTemplate', activeEmailTemplate);
   return (
     <div>
       <EmailWrapper>

--- a/client/src/components/pages/SessionDetails/SessionSurveys/ScheduleEmailsList.js
+++ b/client/src/components/pages/SessionDetails/SessionSurveys/ScheduleEmailsList.js
@@ -14,6 +14,8 @@ import {
   FormWrapper,
 } from '../SessionDetails.Style';
 
+import { readableSurveysNamePairs } from '../../../../constants/index';
+
 const ScheduleEmailsList = ({
   handleDrawerOpen,
   scheduledEmails,
@@ -39,9 +41,11 @@ const ScheduleEmailsList = ({
       {filteredScheduledEmails && filteredScheduledEmails.length > 0 ? (
         <TableWrapper>
           <TableHeader>
-            <Text>
+            <Text style={{ fontWeight: 500 }}>
               Currently scheduled{' '}
-              {surveyType.includes('pre') ? 'Pre-Session' : 'Post-Session'}{' '}
+              <span style={{ fontWeight: 700, textDecoration: 'underline' }}>
+                {readableSurveysNamePairs[surveyType]}
+              </span>{' '}
               Survey Email
             </Text>
           </TableHeader>

--- a/client/src/components/pages/SessionDetails/index.js
+++ b/client/src/components/pages/SessionDetails/index.js
@@ -166,7 +166,6 @@ class SessionDetails extends Component {
     this.setState({
       visible: true,
       drawerKey: nextKey,
-      surveyType: null,
     });
   };
 

--- a/client/src/components/pages/UserResults/panels.js
+++ b/client/src/components/pages/UserResults/panels.js
@@ -42,14 +42,14 @@ export default {
     ),
     render: ({
       results,
-      role,
       handleFilteredData,
       defaultFilters,
       hiddenFields,
+      resultForRole,
     }) => (
       <Reach
         data={results}
-        role={role}
+        role={resultForRole}
         handleFilteredData={handleFilteredData}
         defaultFilters={defaultFilters}
         hiddenFields={hiddenFields}


### PR DESCRIPTION
- clear the previous filters when navigating to another page
- prevent the ability to schedule emails when the email list is empty
- Fix bug found when scheduling emails (it was storing survey type null)